### PR TITLE
addressコントローラーの文法エラーの修正

### DIFF
--- a/app/controllers/api/v1/address_controller.rb
+++ b/app/controllers/api/v1/address_controller.rb
@@ -2,4 +2,5 @@ class Api::V1::AddressController < ApplicationController
   def index
     addresses = Addresses.all
     render json: addresses
+  end
 end


### PR DESCRIPTION
## 概要
- `address`コントローラーの`index`アクションにおいて、`end`が不足していたことによる
文法エラーが発生していたので修正しました。
## 実施したこと
- [X] `address#index`アクションの文末に`end`を追加