### PR TITLE
videosコントローラーの文法エラーの修正

### DIFF
--- a/app/controllers/api/v1/videos_controller.rb
+++ b/app/controllers/api/v1/videos_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::VideosController < ApplicationController
-  before_action: set_video, only: %i[show update destroy]
+  before_action :set_video, only: %i[show update destroy]
 
   def index
     videos = Video.all


### PR DESCRIPTION
## 概要
- `videos`コントローラーの`before_action`において、`:`(コロン)の位置間違いによる
文法エラーが発生していたので修正しました。
## 実施したこと
- [x] `videos`コントローラーの`before_action`のコロンの位置を修正
  
- 修正前
```rb:videos_controller.rb
class Api::V1::VideosController < ApplicationController
  before_action: set_video, only: %i[show update destroy]
# ...
```
- 修正後
```rb:videos_controller.rb
class Api::V1::VideosController < ApplicationController
  before_action :set_video, only: %i[show update destroy]
# ...
```